### PR TITLE
Improvements to COR interface

### DIFF
--- a/@Assignments/Assignments.m
+++ b/@Assignments/Assignments.m
@@ -2,12 +2,36 @@ classdef Assignments
     properties
         starts_with
         ends_with
+        end_range
+        start_range
     end
 
     methods
-        function self = Assignments(ends_with, starts_with)
+        function self = Assignments(ends_with, starts_with, end_range, start_range)
+            % Creates an assignment of how Trajectories should be split.
+            % ENDS_WITH: the name of the loading condition
+            % STARTS_WITH: the starting loading condition
+            % END_RANGE: [start n]. Skips the last `start` elements of the list. Going backwards, assigns `n` elements to the ending list.
+            %     i.e. `my_arr(end-start:-1:end-n)
+            % START_RANGE: [start n]. After `start` elements, the next `n` will be assigned to the starting loading condition.
+            %     i.e. `my_arr(start:n)
+            arguments
+                ends_with
+                starts_with
+                end_range = [10 30]
+                start_range = [10 30]
+            end
+
             self.ends_with = ends_with;
             self.starts_with = starts_with;
+            self.end_range = end_range;
+            self.start_range = start_range;
+        end
+
+        function assignment = is(self, loading_condition)
+            loading_conditions = string([self.ends_with]);
+            is_lc = loading_conditions == loading_condition;
+            assignment = self(is_lc);
         end
     end
 end

--- a/@CentreOfRotation/CentreOfRotation.m
+++ b/@CentreOfRotation/CentreOfRotation.m
@@ -1,5 +1,6 @@
 classdef CentreOfRotation
     properties
+        specimen
         loading_condition
         angle
         state
@@ -9,18 +10,24 @@ classdef CentreOfRotation
     end
 
     methods
-        function self = CentreOfRotation(loading_condition, angle, state, oTf)
+        function self = CentreOfRotation(specimen, loading_condition, angle, state, oTf)
             % Uses tsTorigin to calculate the transform from tsTf 
-            arguments
-                loading_condition string
-                angle
-                state
-                oTf (4, 4, :) %femur relative to origin (identity matrix)
+            % arguments
+            %     loading_condition string
+            %     angle
+            %     state
+            %     oTf (4, 4, :) %femur relative to origin (identity matrix)
+            % end
+
+            if nargin == 0
+                return
             end
 
+
+            self.specimen = categorical(specimen);
             self.loading_condition = categorical(loading_condition);
-            self.angle = angle;
             self.state = categorical(state);
+            self.angle = categorical(angle);
 
             if all(isnan(oTf), "all")
                 self.intersection = [NaN; NaN];

--- a/@CentreOfRotation/CentreOfRotation.m
+++ b/@CentreOfRotation/CentreOfRotation.m
@@ -2,6 +2,7 @@ classdef CentreOfRotation
     properties
         specimen
         loading_condition
+        is_right_knee
         angle
         state
         direction
@@ -10,7 +11,7 @@ classdef CentreOfRotation
     end
 
     methods
-        function self = CentreOfRotation(specimen, loading_condition, angle, state, oTf)
+        function self = CentreOfRotation(specimen, loading_condition, angle, state, oTf, is_right_knee)
             % Uses tsTorigin to calculate the transform from tsTf 
             % arguments
             %     loading_condition string
@@ -28,6 +29,7 @@ classdef CentreOfRotation
             self.loading_condition = loading_condition;
             self.state = state;
             self.angle = angle;
+            self.is_right_knee = is_right_knee;
 
             if all(isnan(oTf), "all")
                 self.intersection = [NaN; NaN];

--- a/@CentreOfRotation/CentreOfRotation.m
+++ b/@CentreOfRotation/CentreOfRotation.m
@@ -24,10 +24,10 @@ classdef CentreOfRotation
             end
 
 
-            self.specimen = categorical(specimen);
-            self.loading_condition = categorical(loading_condition);
-            self.state = categorical(state);
-            self.angle = categorical(angle);
+            self.specimen = specimen;
+            self.loading_condition = loading_condition;
+            self.state = state;
+            self.angle = angle;
 
             if all(isnan(oTf), "all")
                 self.intersection = [NaN; NaN];

--- a/@CentreOfRotation/average.m
+++ b/@CentreOfRotation/average.m
@@ -1,0 +1,28 @@
+function cor_average = average(self)
+    arguments
+        self CentreOfRotation
+    end
+
+    states_all = [self.state];
+    angles_all = [self.angle];
+    loading_conditions_all = [self.loading_condition];
+
+    states = unique(states_all);
+    angles = unique(angles_all);
+    loading_conditions = unique(loading_conditions_all);
+
+    for ag = 1:numel(angles)
+        angle = angles(ag);
+        is_angle = angles == angle;
+        for st = 1:numel(states)
+            state = states(st);
+            is_state = states == state;
+            for lc = 1:numel(loading_conditions)
+                loading_condition = loading_conditions(lc);
+                is_lc = loading_conditions == loading_condition;
+
+            end
+        end
+    end
+
+end

--- a/@CentreOfRotation/average.m
+++ b/@CentreOfRotation/average.m
@@ -3,26 +3,5 @@ function cor_average = average(self)
         self CentreOfRotation
     end
 
-    states_all = [self.state];
-    angles_all = [self.angle];
-    loading_conditions_all = [self.loading_condition];
-
-    states = unique(states_all);
-    angles = unique(angles_all);
-    loading_conditions = unique(loading_conditions_all);
-
-    for ag = 1:numel(angles)
-        angle = angles(ag);
-        is_angle = angles == angle;
-        for st = 1:numel(states)
-            state = states(st);
-            is_state = states == state;
-            for lc = 1:numel(loading_conditions)
-                loading_condition = loading_conditions(lc);
-                is_lc = loading_conditions == loading_condition;
-
-            end
-        end
-    end
-
+    cor_average = CentreOfRotationAverage(self);
 end

--- a/@CentreOfRotation/correct_side.m
+++ b/@CentreOfRotation/correct_side.m
@@ -1,0 +1,11 @@
+function cor = correct_side(self)
+    cor = self;
+
+    mask = ~[cor.is_right_knee];
+
+    for i = find(mask)
+        cor(i).intersection(1) = -cor(i).intersection(1);
+        cor(i).origin(1)       = -cor(i).origin(1);
+        cor(i).direction(1)    = -cor(i).direction(1);
+    end
+end

--- a/@CentreOfRotation/plot.m
+++ b/@CentreOfRotation/plot.m
@@ -32,10 +32,9 @@ function plots = plot(self, digitisation)
 
             is_angle = angles_all == angle;
 
-            figure;
-            tiledlayout(round(numel(loading_conditions)/2), 2)
+            % tiledlayout(round(numel(loading_conditions)/2), 2)
             for lc = 1:numel(loading_conditions)
-                nexttile(lc);
+                figure;
                 hold on; grid on;
                 loading_condition = loading_conditions(lc);
                 is_lc = loading_conditions_all == loading_condition;
@@ -78,13 +77,16 @@ function plots = plot(self, digitisation)
                 axis equal; grid on;
                 xlim([-150 150]);
                 title(replace(loading_condition, '_', ' '));
+                sgtitle([specimen string(angles(ang))]);
+
+
+                root = fileparts(digitisation(1).filepath);
+                path = fullfile(root, 'results', 'centre_of_rotation', loading_condition);
+                mkdir(path)
+                filename = strjoin([specimen, '_', string(angles(ang)), '.png'], '');
+                exportgraphics(gcf, fullfile(path, filename));
             end
 
-            sgtitle([specimen angles(ang)]);
-            root = fileparts(digitisation(1).filepath);
-            path = fullfile(root, 'results', 'centre_of_rotation');
-            filename = strjoin([specimen, '_', angles(ang), '.svg'], '');
-            exportgraphics(gcf, fullfile(path, filename));
         end
     end
 

--- a/@CentreOfRotation/plot.m
+++ b/@CentreOfRotation/plot.m
@@ -72,12 +72,18 @@ function plots = plot(self, digitisation)
                 end
                 legend('Location', 'northoutside', 'NumColumns', 4);
                 digitisation_spec.visualise_surfaces();
-                xlabel('\leftarrow Lateral    Medial \rightarrow')
+                xlabel('\leftarrow Medial    Lateral \rightarrow')
                 ylabel('\leftarrow Anterior    Posterior \rightarrow')
                 axis equal; grid on;
                 xlim([-150 150]);
                 title(replace(loading_condition, '_', ' '));
-                sgtitle([specimen string(angles(ang))]);
+
+                if digitisation_spec.is_right_knee
+                    txt = 'Right';
+                else
+                    txt = 'Left';
+                end
+                sgtitle([strjoin([specimen, txt], ' '), strjoin([string(angles(ang)) 'degrees'], ' ')]);
 
 
                 root = fileparts(digitisation(1).filepath);

--- a/@CentreOfRotation/plot.m
+++ b/@CentreOfRotation/plot.m
@@ -23,23 +23,22 @@ function plots = plot(self, digitisation)
     t = [-60; 60];
 
 
-    i = 0;
     for sp = 1:numel(specimens)
         specimen = specimens(sp);
-        i = i+1;
         is_specimen = specimens_all == specimen;
-        digitisation_spec = digitisation.find(string(specimen));
+        digitisation_spec = digitisation.find(specimen);
         for ang = 1:numel(angles)
             angle = angles(ang);
 
-            sgtitle([specimen angles(ang)]);
             is_angle = angles_all == angle;
 
+            figure;
+            tiledlayout(round(numel(loading_conditions)/2), 2)
             for lc = 1:numel(loading_conditions)
+                nexttile(lc);
+                hold on; grid on;
                 loading_condition = loading_conditions(lc);
                 is_lc = loading_conditions_all == loading_condition;
-
-                fig(i) = figure; hold on;
 
                 for st = 1:numel(states)
                     state = states(st);
@@ -65,37 +64,28 @@ function plots = plot(self, digitisation)
                     x = x0 + t .* dx;
                     y = y0 + t .* dy;
 
-                    plots = plot(mean(x, 2), mean(y, 2), [ls mk], 'Color', colour, 'MarkerSize', 4, 'MarkerIndices', round(linspace(1,size(x,1),5)), 'DisplayName', replace(string(state), '_', ' '));
+                    plots = plot(mean(x, 2), mean(y, 2), [ls mk], 'Color', colour, 'MarkerSize', 4, 'MarkerIndices', round(linspace(1,size(x,1),5)), 'DisplayName', replace(state, '_', ' '));
                     scatter(intersection(1, is_datum), intersection(2, is_datum), 40, colour, mk, 'filled', 'HandleVisibility', "off");
 
                     axis equal;
                     % plots = plot(x, y, [ls mk], 'Color', colour, 'MarkerSize', 4, 'MarkerIndices', round(linspace(1,size(x,1),5)), 'HandleVisibility', "off");
-                    % scatter(intersection(1, is_datum), intersection(2, is_datum), 40, colour, mk, 'filled', 'DisplayName', string(state));
+                    % scatter(intersection(1, is_datum), intersection(2, is_datum), 40, colour, mk, 'filled', 'DisplayName', state);
                 end
+                legend('Location', 'northoutside', 'NumColumns', 4);
                 digitisation_spec.visualise_surfaces();
                 xlabel('\leftarrow Lateral    Medial \rightarrow')
-                ylabel('\leftarrow Posterior    Anterior \rightarrow')
-                xlim([-150 150]);
+                ylabel('\leftarrow Anterior    Posterior \rightarrow')
                 axis equal; grid on;
-                sgtitle([specimen loading_condition])
-                states_clean = replace(string(states), '_', ' ');
-                legend;
-                keyboard
+                xlim([-150 150]);
+                title(replace(loading_condition, '_', ' '));
             end
 
-            % State/colour legend
-
-
-        i = i+1;
+            sgtitle([specimen angles(ang)]);
+            root = fileparts(digitisation(1).filepath);
+            path = fullfile(root, 'results', 'centre_of_rotation');
+            filename = strjoin([specimen, '_', angles(ang), '.svg'], '');
+            exportgraphics(gcf, fullfile(path, filename));
         end
-        i = i+1;
-
-
-
-
-        % [label_x, end_idx] = max(x, [], 1);
-        % label_y = y(sub2ind(size(y), end_idx, 1:size(y,2)));
-        % text(label_x, label_y, arrayfun(@(v) sprintf('%.0f°', v), flexion(n), UniformOutput=false));
     end
 
 end

--- a/@CentreOfRotation/plot.m
+++ b/@CentreOfRotation/plot.m
@@ -1,112 +1,101 @@
-function plots = plot(self)
+function plots = plot(self, digitisation)
     arguments
         self CentreOfRotation
+        digitisation Digitisation
     end
     direction = [self.direction];
     origin = [self.origin];
     intersection = [self.intersection];
     angles_all = [self.angle];
     states_all = [self.state];
+    specimens_all = [self.specimen];
     loading_conditions_all = [self.loading_condition];
 
     states = unique(states_all);
     loading_conditions = unique(loading_conditions_all);
     angles = unique(angles_all);
+    specimens = unique(specimens_all);
 
-    colours = lines(numel(loading_conditions) + 2);
+    colours = lines(numel(states));
     linestyles = {'-', '--', ':', '-.'};
     markers = {'o', 's', '^', 'd', 'v', 'p', 'h', 'x'};
 
     t = [-60; 60];
 
 
+    i = 0;
+    for sp = 1:numel(specimens)
+        specimen = specimens(sp);
+        i = i+1;
+        is_specimen = specimens_all == specimen;
+        digitisation_spec = digitisation.find(string(specimen));
+        for ang = 1:numel(angles)
+            angle = angles(ang);
 
-    for ang = 1:numel(angles)
-        angle = angles(ang);
-        fig(ang) = figure; hold on;
-
-        %% Create colour and linestyle handles
-        for st = 1:numel(states)
-            ls = linestyles{mod(st-1, 4) + 1};
-            mk = markers{st};
-            ls_handles(st) = plot(NaN, NaN, mk, Color='k', MarkerSize=4);
-            % ls_handles(st) = plot(NaN, NaN, [ls mk], Color='k', MarkerSize=4);
-        end
-
-        for lc = 1:numel(loading_conditions)
-            colour_handles(lc) = plot(NaN, NaN, 's', Color=colours(lc,:), MarkerFaceColor=colours(lc,:), MarkerSize=8);
-
-        end
-        %%
-
-        sgtitle(sprintf('%.0f°', angles(ang)));
-        is_angle = angles_all == angle;
-
-        for st = 1:numel(states)
-            state = states(st);
-            is_state = states_all == state;
-
-            % Create styles
-            ls = linestyles{mod(st-1, 4) + 1};
-            mk = markers{st};
+            sgtitle([specimen angles(ang)]);
+            is_angle = angles_all == angle;
 
             for lc = 1:numel(loading_conditions)
                 loading_condition = loading_conditions(lc);
                 is_lc = loading_conditions_all == loading_condition;
 
-                is_datum = is_angle & is_state & is_lc;
-                if ~any(is_datum), continue; end
+                fig(i) = figure; hold on;
 
-                colour = colours(lc, :);
+                for st = 1:numel(states)
+                    state = states(st);
+                    is_state = states_all == state;
+
+                    % Create styles
+                    ls = linestyles{mod(st-1, 4) + 1};
+                    mk = markers{st};
+
+
+                    is_datum = is_angle & is_state & is_lc & is_specimen;
+                    if ~any(is_datum), continue; end
+
+                    colour = colours(st, :);
 
 
 
-                dx = direction(1, is_datum);
-                dy = direction(2, is_datum);
-                x0 = origin(1, is_datum);
-                y0 = origin(2, is_datum);
+                    dx = direction(1, is_datum);
+                    dy = direction(2, is_datum);
+                    x0 = origin(1, is_datum);
+                    y0 = origin(2, is_datum);
 
-                x = x0 + t .* dx;
-                y = y0 + t .* dy;
+                    x = x0 + t .* dx;
+                    y = y0 + t .* dy;
 
-                % plots = plot(x, y, [ls mk], Color=colour, MarkerSize=4, MarkerIndices=round(linspace(1,size(x,1),5)), HandleVisibility="off");
-    %             semilogx(intersection(1, is_datum), intersection(2, is_datum), mk, ...
-    % Color=colour, MarkerFaceColor=colour, MarkerSize=6, ...
-    % HandleVisibility='off');
-                scatter(intersection(1, is_datum), intersection(2, is_datum), 40, colour, mk, 'filled', HandleVisibility="off");
-            axis equal; grid on;
+                    plots = plot(mean(x, 2), mean(y, 2), [ls mk], 'Color', colour, 'MarkerSize', 4, 'MarkerIndices', round(linspace(1,size(x,1),5)), 'DisplayName', replace(string(state), '_', ' '));
+                    scatter(intersection(1, is_datum), intersection(2, is_datum), 40, colour, mk, 'filled', 'HandleVisibility', "off");
+
+                    axis equal;
+                    % plots = plot(x, y, [ls mk], 'Color', colour, 'MarkerSize', 4, 'MarkerIndices', round(linspace(1,size(x,1),5)), 'HandleVisibility', "off");
+                    % scatter(intersection(1, is_datum), intersection(2, is_datum), 40, colour, mk, 'filled', 'DisplayName', string(state));
+                end
+                digitisation_spec.visualise_surfaces();
+                xlabel('\leftarrow Lateral    Medial \rightarrow')
+                ylabel('\leftarrow Posterior    Anterior \rightarrow')
+                xlim([-150 150]);
+                axis equal; grid on;
+                sgtitle([specimen loading_condition])
+                states_clean = replace(string(states), '_', ' ');
+                legend;
+                keyboard
             end
+
+            % State/colour legend
+
+
+        i = i+1;
         end
+        i = i+1;
 
-           % State/colour legend
 
-           ax = gca;
-           states_clean = replace(string(states), '_', ' ');
-           leg1 = legend(ax, ls_handles, states_clean, Location='northeast');
-           title(leg1, 'State');
 
-           % LC/linestyle legend — black so colour doesn't interfere
-           ax2 = axes('position',get(gca,'position'),'visible','off');
-           lc_clean = replace(string(loading_conditions), '_', ' ');
-           leg2 = legend(ax2, colour_handles, lc_clean, Location='northeast');
-           title(leg2, 'Loading condition');
 
-           drawnow;  % flush so Position is populated
-           leg1_pos = leg1.Position;
-           leg2_pos = leg2.Position;
-           leg2.Position = [leg1_pos(1) - leg2_pos(3) - 0.01, ...
-               leg1_pos(2) + leg1_pos(4) - leg2_pos(4), ...
-               leg2_pos(3), leg2_pos(4)];
-
-           % Return handle back to axis with all the data
-           set(fig(ang), 'CurrentAxes', ax);
+        % [label_x, end_idx] = max(x, [], 1);
+        % label_y = y(sub2ind(size(y), end_idx, 1:size(y,2)));
+        % text(label_x, label_y, arrayfun(@(v) sprintf('%.0f°', v), flexion(n), UniformOutput=false));
     end
-
-
-
-
-    % [label_x, end_idx] = max(x, [], 1);
-    % label_y = y(sub2ind(size(y), end_idx, 1:size(y,2)));
-    % text(label_x, label_y, arrayfun(@(v) sprintf('%.0f°', v), flexion(n), UniformOutput=false));
 
 end

--- a/@CentreOfRotationAverage/CentreOfRotationAverage.m
+++ b/@CentreOfRotationAverage/CentreOfRotationAverage.m
@@ -1,0 +1,19 @@
+classdef CentreOfRotationAverage
+    properties
+        loading_condition
+        angle
+        state
+        direction
+        direction_std
+        origin_std
+        intersection_std
+    end
+
+    methods
+        function self = CentreOfRotationAverage(cor)
+            self.loading_condition = loading_condition;
+            self.angle = angle;
+            self.state = state;
+        end
+    end
+end

--- a/@CentreOfRotationAverage/CentreOfRotationAverage.m
+++ b/@CentreOfRotationAverage/CentreOfRotationAverage.m
@@ -5,15 +5,67 @@ classdef CentreOfRotationAverage
         state
         direction
         direction_std
+        origin
         origin_std
+        intersection
         intersection_std
     end
 
     methods
         function self = CentreOfRotationAverage(cor)
-            self.loading_condition = loading_condition;
-            self.angle = angle;
-            self.state = state;
+            if nargin == 0
+                return
+            end
+
+            states_all = [cor.state];
+            angles_all = [cor.angle];
+            loading_conditions_all = [cor.loading_condition];
+
+            states = unique(states_all);
+            angles = unique(angles_all);
+            loading_conditions = unique(loading_conditions_all);
+
+            i = 1;
+            self(numel(states) * numel(angles) * numel(loading_conditions)) = CentreOfRotationAverage();
+
+            for ag = 1:numel(angles)
+                angle = angles(ag);
+                is_angle = angles_all == angle;
+                for st = 1:numel(states)
+                    state = states(st);
+                    is_state = states_all == state;
+                    for lc = 1:numel(loading_conditions)
+                        loading_condition = loading_conditions(lc);
+                        is_lc = loading_conditions_all == loading_condition;
+
+                        mask = is_angle & is_state & is_lc;
+
+                        data = cor(mask);
+
+                        origin = median([data.origin], 2, "omitmissing");
+                        origin_std = std([data.origin], 0, 2, "omitmissing");
+
+                        direction = median([data.direction], 2, "omitmissing");
+                        direction_std = std([data.direction], 0, 2, "omitmissing");
+
+                        intersection = median([data.intersection], 2, "omitmissing");
+                        intersection_std = std([data.intersection], 0, 2, "omitmissing");
+
+                        self(i).loading_condition = loading_condition;
+                        self(i).angle = angle;
+                        self(i).state = state;
+                        self(i).direction = direction;
+                        self(i).direction_std = direction_std;
+                        self(i).origin = origin;
+                        self(i).origin_std = origin_std;
+                        self(i).intersection = intersection;
+                        self(i).intersection_std = intersection_std;
+
+                        i = i + 1;
+
+                    end
+                end
+            end
         end
     end
 end

--- a/@CentreOfRotationAverage/plot.m
+++ b/@CentreOfRotationAverage/plot.m
@@ -1,7 +1,8 @@
-function plots = plot(self, model)
+function plots = plot(self, model, root)
     arguments
         self CentreOfRotationAverage
         model triangulation
+        root
     end
     direction = [self.direction];
     origin = [self.origin];
@@ -27,10 +28,10 @@ function plots = plot(self, model)
 
         is_angle = angles_all == angle;
 
-        figure;
-        tiledlayout(round(numel(loading_conditions)/2), 2)
+        % tiledlayout(round(numel(loading_conditions)/2), 2)
         for lc = 1:numel(loading_conditions)
-            nexttile(lc);
+            figure;
+            % nexttile(lc);
             hold on; grid on;
             loading_condition = loading_conditions(lc);
             is_lc = loading_conditions_all == loading_condition;
@@ -68,20 +69,21 @@ function plots = plot(self, model)
             legend('Location', 'northoutside', 'NumColumns', 4);
 
             place_model(model);
-            xlabel('\leftarrow Lateral    Medial \rightarrow')
+
+            xlabel('\leftarrow Medial    Lateral \rightarrow')
             ylabel('\leftarrow Anterior    Posterior \rightarrow')
             axis equal; grid on;
             xlim([-150 150]);
             title(replace(loading_condition, '_', ' '));
+
+            sgtitle(strjoin([string(angles(ang)) 'degrees'], ' '));
+
+            path = fullfile(root, 'results', 'cor_average', string(angles(ang)));
+            mkdir(path)
+            filename = strjoin([loading_condition, '.png'], '');
+            exportgraphics(gcf, fullfile(path, filename));
         end
 
-
-        keyboard
-        sgtitle(strjoin([angles(ang) 'degrees'], ' '));
-        root = fileparts(digitisation(1).filepath);
-        path = fullfile(root, 'results', 'centre_of_rotation');
-        filename = strjoin([angles(ang), 'degrees', '.svg'], '');
-        exportgraphics(gcf, fullfile(path, filename));
     end
 end
 
@@ -89,7 +91,7 @@ end
 function place_model(model)
     patch('Vertices', model.Points, 'Faces', model.ConnectivityList, 'FaceColor', '#eadfc3', 'EdgeColor', 'none', 'HandleVisibility', 'off');
     zlim([-100, 5])
-    camlight
+    camlight("right", "infinite");
     % shape = alphaShape(model.Points);
     % plot(shape, EdgeAlpha=0.1)
 end

--- a/@CentreOfRotationAverage/plot.m
+++ b/@CentreOfRotationAverage/plot.m
@@ -1,0 +1,95 @@
+function plots = plot(self, model)
+    arguments
+        self CentreOfRotationAverage
+        model triangulation
+    end
+    direction = [self.direction];
+    origin = [self.origin];
+    intersection = [self.intersection];
+    intersection_std = [self.intersection_std];
+    angles_all = [self.angle];
+    states_all = [self.state];
+    loading_conditions_all = [self.loading_condition];
+
+    states = unique(states_all);
+    loading_conditions = unique(loading_conditions_all);
+    angles = unique(angles_all);
+
+    colours = lines(numel(states));
+    linestyles = {'-', '--', ':', '-.'};
+    markers = {'o', 's', '^', 'd', 'v', 'p', 'h', 'x'};
+
+    t = [-60; 60];
+
+
+    for ang = 1:numel(angles)
+        angle = angles(ang);
+
+        is_angle = angles_all == angle;
+
+        figure;
+        tiledlayout(round(numel(loading_conditions)/2), 2)
+        for lc = 1:numel(loading_conditions)
+            nexttile(lc);
+            hold on; grid on;
+            loading_condition = loading_conditions(lc);
+            is_lc = loading_conditions_all == loading_condition;
+
+            for st = 1:numel(states)
+                state = states(st);
+                is_state = states_all == state;
+
+                % Create styles
+                ls = linestyles{mod(st-1, 4) + 1};
+                mk = markers{st};
+
+
+                is_datum = is_angle & is_state & is_lc;
+                if ~any(is_datum), continue; end
+
+                colour = colours(st, :);
+
+
+
+                dx = direction(1, is_datum);
+                dy = direction(2, is_datum);
+                x0 = origin(1, is_datum);
+                y0 = origin(2, is_datum);
+
+                x = x0 + t .* dx;
+                y = y0 + t .* dy;
+
+                plots = plot(mean(x, 2), mean(y, 2), [ls mk], 'Color', colour, 'MarkerSize', 4, 'MarkerIndices', round(linspace(1,size(x,1),5)), 'DisplayName', replace(state, '_', ' '));
+                scatter(intersection(1, is_datum), intersection(2, is_datum), 40, colour, mk, 'filled', 'HandleVisibility', "off");
+                errorbar(intersection(1, is_datum), intersection(2, is_datum), intersection_std(1, is_datum), 'horizontal', 'Color', colour, 'HandleVisibility', "off");
+                % plots = plot(x, y, [ls mk], 'Color', colour, 'MarkerSize', 4, 'MarkerIndices', round(linspace(1,size(x,1),5)), 'HandleVisibility', "off");
+                % scatter(intersection(1, is_datum), intersection(2, is_datum), 40, colour, mk, 'filled', 'DisplayName', state);
+            end
+            legend('Location', 'northoutside', 'NumColumns', 4);
+
+            place_model(model);
+            xlabel('\leftarrow Lateral    Medial \rightarrow')
+            ylabel('\leftarrow Anterior    Posterior \rightarrow')
+            axis equal; grid on;
+            xlim([-150 150]);
+            title(replace(loading_condition, '_', ' '));
+        end
+
+
+        keyboard
+        sgtitle(strjoin([angles(ang) 'degrees'], ' '));
+        root = fileparts(digitisation(1).filepath);
+        path = fullfile(root, 'results', 'centre_of_rotation');
+        filename = strjoin([angles(ang), 'degrees', '.svg'], '');
+        exportgraphics(gcf, fullfile(path, filename));
+    end
+end
+
+
+function place_model(model)
+    patch('Vertices', model.Points, 'Faces', model.ConnectivityList, 'FaceColor', '#eadfc3', 'EdgeColor', 'none', 'HandleVisibility', 'off');
+    zlim([-100, 5])
+    camlight
+    % shape = alphaShape(model.Points);
+    % plot(shape, EdgeAlpha=0.1)
+end

--- a/@Trajectory/Trajectory.m
+++ b/@Trajectory/Trajectory.m
@@ -1,4 +1,4 @@
-classdef Trajectory < handle
+classdef Trajectory < handle & matlab.mixin.Copyable
     properties
         SpecimenName
         SpecimenState
@@ -31,13 +31,8 @@ classdef Trajectory < handle
             all_signals = vertcat(field_names{:});
             out = string(unique(all_signals));
         end
-        function out = specimen(self, arg)
-            if nargin > 1
-                self.SpecimenName = arg;
-                out = self;
-            else
-                out = [self.SpecimenName];
-            end
+        function out = specimens(self)
+            out = [self.SpecimenName];
         end
         function out = states(self)
             out = [self.SpecimenState];

--- a/@Trajectory/centre_of_rotation.m
+++ b/@Trajectory/centre_of_rotation.m
@@ -140,6 +140,6 @@ function cor = centre_of_rotation(self, angles, intact, neutral)
         % if self(n).loading_conditions == neutral && self(n).states == intact
         %     error("This is supposed to be an identity matrix")
         % end
-        cor(n) = CentreOfRotation(self(n).specimens, self(n).loading_conditions, angles(n), self(n).states, oTf);
+        cor(n) = CentreOfRotation(self(n).specimens, self(n).loading_conditions, angles(n), self(n).states, oTf, self(n).IsRightKnee);
     end
 end

--- a/@Trajectory/centre_of_rotation.m
+++ b/@Trajectory/centre_of_rotation.m
@@ -56,10 +56,14 @@ function cor = centre_of_rotation(self, angles, intact, neutral)
         end
 
         fTts = self(n).Transform.fTts;
-        tsTf = pageinv(fTts);
-        tsTf_mean = mean(tsTf, 3, "omitmissing");
+        fTts_mean = mean(fTts, 3, "omitmissing");
+        tsTf_mean = pageinv(fTts_mean);
         % Missing 
-        oTf = oTts(:, :, is_specimen, is_angle) * tsTf_mean;
+        if isempty(tsTf_mean)
+            oTf = [];
+        else
+            oTf = oTts(:, :, is_specimen, is_angle) * tsTf_mean;
+        end
         % if self(n).loading_conditions == neutral && self(n).states == intact
         %     error("This is supposed to be an identity matrix")
         % end

--- a/@Trajectory/centre_of_rotation.m
+++ b/@Trajectory/centre_of_rotation.m
@@ -1,3 +1,76 @@
+% function cor = centre_of_rotation(self, angles, intact)
+%     % looks for folder names (states) that include COR_STRING to create a
+%     % piecewise centre of rotation. "COR" by default.
+%     arguments
+%         self Trajectory
+%         angles
+%         intact string = "Intact"
+%     end
+%
+%     if numel(angles) ~= numel(self)
+%         error("The number of Trajectory must match the number of angles")
+%     end
+%
+%
+%     is_intact = self.states == intact;
+%     if ~any(is_intact)
+%         error("No specimen with %s state", intact);
+%     end
+%     loading_conditions_all = self.loading_conditions;
+%     loading_conditions = unique(loading_conditions_all);
+%     specimens_all = self.specimens;
+%     specimens = unique(specimens_all);
+%     unique_angles = unique(angles);
+%
+%
+%     for a = 1:numel(unique_angles)
+%         angle = unique_angles(a);
+%         is_angle = angles == angle;
+%         for sp = 1:numel(specimens)
+%             is_specimen = specimens_all == specimens(sp);
+%             for lc = 1:numel(loading_conditions)
+%                 is_lc = loading_conditions_all == loading_conditions(lc);
+%
+%                 mask = is_angle & is_specimen & is_lc & is_intact;
+%
+%                 transforms_intact = [self(mask).Transform];
+%                 fTts_intact = {transforms_intact.fTts};
+%                 is_empty = cellfun(@isempty, fTts_intact);
+%                 if all(is_empty)
+%                     error("Missing implementation for when the tibial surface was not digitised. Will use digitised tibia eventually")
+%                 end
+%                 fTts_curr = mean(cat(3, fTts_intact{:}), 3, "omitmissing");
+%                 oTts(:, :, sp, a, lc) = fTts_curr; % oTf is eye(4)
+%             end
+%
+%         end
+%     end
+%
+%     cor(numel(self)) = CentreOfRotation;
+%     for n = 1:numel(self)
+%         is_specimen = self(n).specimens == specimens;
+%         is_angle = angles(n) == unique_angles;
+%         is_lc = self(n).loading_conditions == loading_conditions;
+%         if ~any(is_specimen)
+%             warning("No intact neutral for specimen %s. Skipping", self(n).specimens);
+%         end
+%
+%         fTts = self(n).Transform.fTts;
+%         fTts_mean = mean(fTts, 3, "omitmissing");
+%         % Missing 
+%         if isempty(fTts_mean) || all(isnan(fTts_mean), "all")
+%             oTf = [];
+%         else
+%             oTf = oTts(:, :, is_specimen, is_angle, is_lc) / fTts_mean;
+%         end
+%         % if self(n).loading_conditions == neutral && self(n).states == intact
+%         %     error("This is supposed to be an identity matrix")
+%         % end
+%         cor(n) = CentreOfRotation(self(n).specimens, self(n).loading_conditions, angles(n), self(n).states, oTf);
+%     end
+% end
+
+% Uses intact neutral for every rotation
 function cor = centre_of_rotation(self, angles, intact, neutral)
     % looks for folder names (states) that include COR_STRING to create a
     % piecewise centre of rotation. "COR" by default.

--- a/@Trajectory/centre_of_rotation.m
+++ b/@Trajectory/centre_of_rotation.m
@@ -1,0 +1,68 @@
+function cor = centre_of_rotation(self, angles, intact, neutral)
+    % looks for folder names (states) that include COR_STRING to create a
+    % piecewise centre of rotation. "COR" by default.
+    arguments
+        self Trajectory
+        angles
+        intact string = "Intact"
+        neutral string = "Neutral"
+    end
+
+    if numel(angles) ~= numel(self)
+        error("The number of Trajectory must match the number of angles")
+    end
+
+
+    is_intact = self.states == intact;
+    is_neutral = self.loading_conditions == neutral;
+
+    if ~any(is_intact)
+        error("%s is not a state that exists. Use one of: %s", intact, strjoin(unique(self.states), ', '));
+    end
+    if ~any(is_neutral)
+        error("%s is not a state that exists. Use one of: %s", neutral, strjoin(unique(self.loading_conditions), ', '));
+    end
+
+
+    intacts_neutrals = self(is_intact & is_neutral);
+    specimens = unique(self.specimens);
+    unique_angles = unique(angles);
+
+    for a = 1:numel(unique_angles)
+        angle = unique_angles(a);
+        angles_intact_neutral  = angles(is_intact & is_neutral);
+        is_angle = angles_intact_neutral == angle;
+        for sp = 1:numel(specimens)
+            is_specimen = intacts_neutrals.specimens == specimens(sp);
+            mask = is_angle & is_specimen;
+            transforms_intact_neutral = [intacts_neutrals(mask).Transform];
+            fTts_intact = {transforms_intact_neutral.fTts};
+            is_empty = cellfun(@isempty, fTts_intact);
+
+            if all(is_empty)
+                error("Missing implementation for when the tibial surface was not digitised. Will use digitised tibia")
+            end
+            fTts_curr = mean(cat(3, fTts_intact{:}), 3, "omitmissing");
+            oTts(:, :, sp, a) = fTts_curr; % oTf is eye(4)
+        end
+    end
+
+    cor(numel(self)) = CentreOfRotation;
+    for n = 1:numel(self)
+        is_specimen = self(n).specimens == specimens;
+        is_angle = angles(n) == unique_angles;
+        if ~any(is_specimen)
+            warning("No intact neutral for specimen %s. Skipping", self(n).specimens);
+        end
+
+        fTts = self(n).Transform.fTts;
+        tsTf = pageinv(fTts);
+        tsTf_mean = mean(tsTf, 3, "omitmissing");
+        % Missing 
+        oTf = oTts(:, :, is_specimen, is_angle) * tsTf_mean;
+        % if self(n).loading_conditions == neutral && self(n).states == intact
+        %     error("This is supposed to be an identity matrix")
+        % end
+        cor(n) = CentreOfRotation(self(n).specimens, self(n).loading_conditions, angles(n), self(n).states, oTf);
+    end
+end

--- a/@Trajectory/exclude_state.m
+++ b/@Trajectory/exclude_state.m
@@ -1,0 +1,4 @@
+function trajectories = exclude_state(self, state)
+    is_states = contains(self.states, state, "IgnoreCase", true);
+    trajectories = self(~is_states);
+end

--- a/@Trajectory/include_state.m
+++ b/@Trajectory/include_state.m
@@ -1,0 +1,4 @@
+function trajectories = include_state(self, state)
+    has_state = contains(self.states, state, "IgnoreCase", true);
+    trajectories = self(has_state);
+end

--- a/@Trajectory/plot.m
+++ b/@Trajectory/plot.m
@@ -19,7 +19,7 @@ function fig = plot(self, highlight_idx)
             headers = datum.Properties.VariableNames;
             figure;
             fig(t) = tiledlayout(round(numel(headers)/2), 2);
-            sgtitle([[self(t).SpecimenName ' ' replace(self(t).SpecimenState, '_', ' ') ' ' replace(self(t).loading_condition, '_', ' ')] signals(sg)]);
+            sgtitle([[self(t).SpecimenName ' ' replace(self(t).SpecimenState, '_', ' ') ' ' replace(self(t).LoadingCondition, '_', ' ')] signals(sg)]);
             for h = 1:numel(headers)
                 % Plot data
                 nexttile(h);

--- a/@Trajectory/split_piecewise.m
+++ b/@Trajectory/split_piecewise.m
@@ -1,0 +1,64 @@
+function split_trajectories = split_piecewise(self, assignments)
+    arguments
+        self Trajectory
+        assignments Assignments
+    end
+
+    % Find preallocation size
+    has_conditions_to_split = ismember([self.LoadingCondition], string([assignments.ends_with]));
+    prealloc_size = sum(has_conditions_to_split + 1);
+
+    split_trajectories(prealloc_size) = Trajectory;
+
+    i = 1;
+    for n = 1:numel(self)
+        assignment = assignments.is(self(n).LoadingCondition);
+        if isempty(assignment)
+            split_trajectories(i) = self(n);
+            i = i +1;
+            continue;
+        end
+
+        ends_with = assignment.ends_with;
+        starts_with = assignment.starts_with;
+        end_range = assignment.end_range;
+        start_range = assignment.start_range;
+
+        trajectory = self(n);
+
+        split_trajectories(i) = copy(trajectory);
+        split_trajectories(i).LoadingCondition = starts_with;
+
+        split_trajectories(i+1) = copy(trajectory);
+
+        transforms = fields(trajectory.Transform);
+        for t = 1:numel(transforms)
+            transform = transforms{t};
+            curr_transf = trajectory.Transform.(transform);
+            if isempty(curr_transf) || size(curr_transf, 3) < sum([start_range(:) end_range(:)], "all")
+                split_trajectories(i).Transform.(transform) = [];
+                split_trajectories(i+1).Transform.(transform) = [];
+            else
+                split_trajectories(i).Transform.(transform) = split_trajectories(i).Transform.(transform)(:, :, start_range(1):start_range(2));
+                split_trajectories(i+1).Transform.(transform) = split_trajectories(i+1).Transform.(transform)(:, :, end-end_range(2):end-end_range(1));
+            end
+        end
+
+        signals = fields(trajectory.Kinematics);
+        for sg = 1:numel(signals)
+            signal = signals{sg};
+            curr_sig = trajectory.Kinematics.(signal);
+            if isempty(curr_sig) || size(curr_sig, 3) < sum([start_range(:) end_range(:)], "all")
+                split_trajectories(i).Kinematics.(signal) = [];
+                split_trajectories(i+1).Kinematics.(signal) = [];
+            else
+                split_trajectories(i).Kinematics.(signal) = split_trajectories(i).Kinematics.(signal)(start_range(1):start_range(2), :);
+                split_trajectories(i+1).Kinematics.(signal) = split_trajectories(i+1).Kinematics.(signal)(end-end_range(2):end-end_range(1), :);
+            end
+        end
+
+        i = i + 2;
+
+
+    end
+end

--- a/@Trajectory/split_states.m
+++ b/@Trajectory/split_states.m
@@ -1,0 +1,14 @@
+function [trajectories, secondary_arr] = split_states(self, str)
+    arguments
+        self Trajectory
+        str = "_COR"
+    end
+    trajectories = copy(self);
+    words = split(self.states, str);
+    states = words(:, :, 1);
+    angles = str2double(replace(words(:, :, 2), "_", ""));
+
+    tmp = num2cell(states); % Can't do it with string array or using deal. Requires converting to cell. what a language...
+    [trajectories.SpecimenState] = tmp{:};
+    secondary_arr = angles;
+end


### PR DESCRIPTION
Usage looks something like:
```matlab
assignments(1) = Assignments("Anterior", "Neutral");
assignments(2) = Assignments("External", "Neutral");
assignments(3) = Assignments("Internal", "Neutral");
assignments(4) = Assignments("Anterior_External", "Anterior");
assignments(5) = Assignments("Anterior_Internal", "Anterior");
assignments(6) = Assignments("SPS", "Valgus");

[traj_cor, angles] = trajectories.include_state("COR").split_piecewise(assignments).split_states("_COR");
cor = traj_cor.centre_of_rotation(angles);
```